### PR TITLE
update common infrastructure that is used for build/deploy

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -92,7 +92,7 @@ MAX_AGE = 30
 SUB_DOMAIN = tokens-staging
 HOSTED_ZONE = ala.org.au
 HOSTED_ZONE_ID = Z5991MJJ8ZIPR
-SSL_CERTIFICATE = arn:aws:acm:us-east-1:736913556139:certificate/529da40c-8d50-4776-a34c-2df0e5e57cce
+SSL_CERTIFICATE = arn:aws:acm:us-east-1:736913556139:certificate/4b62cca2-9daf-4e38-b01a-48271ab3311a
 DOCUMENT_ROOT = index.html 
 # app
 VITE_OIDC_AUTHORITY=https://auth.ala.org.au/cas/oidc
@@ -119,7 +119,7 @@ MAX_AGE = 300
 SUB_DOMAIN = tokens
 HOSTED_ZONE = ala.org.au
 HOSTED_ZONE_ID = Z5991MJJ8ZIPR
-SSL_CERTIFICATE = arn:aws:acm:us-east-1:736913556139:certificate/529da40c-8d50-4776-a34c-2df0e5e57cce
+SSL_CERTIFICATE = arn:aws:acm:us-east-1:736913556139:certificate/4b62cca2-9daf-4e38-b01a-48271ab3311a
 DOCUMENT_ROOT = index.html 
 # app
 VITE_OIDC_AUTHORITY=https://auth.ala.org.au/cas/oidc

--- a/config.ini
+++ b/config.ini
@@ -28,10 +28,10 @@ PIPELINE_STACK_NAME = ala-${PRODUCT_NAME}-pipeline-${CLEAN_BRANCH}
 APP_STACK_NAME = ala-${PRODUCT_NAME}-${CLEAN_BRANCH} 
 LAMBDA_STACK_NAME = ala-${PRODUCT_NAME}-lambda-${CLEAN_BRANCH} 
 CODESTAR_CONNECTION = arn:aws:codestar-connections:ap-southeast-2:748909248546:connection/e336fd41-54c2-42e1-97c9-cbd6cc09fe88
-ARTIFACTS_BUCKET = ala-code-pipeline-artifacts-development
-CLOUDFORMATION_SERVICE_ROLE = arn:aws:iam::748909248546:role/cloud-formation-service-role-development
-CODEBUILD_SERVICE_ROLE = arn:aws:iam::748909248546:role/service-role/code-build-service-role-development
-CODEPIPELINE_SERVICE_ROLE = arn:aws:iam::748909248546:role/code-pipeline-service-role-development
+ARTIFACTS_BUCKET = ala-code-pipeline-artifacts-748909-ap-southeast-2-production
+CLOUDFORMATION_SERVICE_ROLE = arn:aws:iam::748909248546:role/cloud-formation-service-role-production
+CODEBUILD_SERVICE_ROLE = arn:aws:iam::748909248546:role/service-role/code-build-service-role-production
+CODEPIPELINE_SERVICE_ROLE = arn:aws:iam::748909248546:role/code-pipeline-service-role-production
 # bucket
 SOURCE_BUCKET = ala-${PRODUCT_NAME}-${CLEAN_BRANCH}
 MAX_AGE = 0
@@ -55,10 +55,10 @@ DEST_EMAIL=test@ala.org.au
 [testing]
 # code pipeline
 CODESTAR_CONNECTION = arn:aws:codestar-connections:ap-southeast-2:748909248546:connection/e336fd41-54c2-42e1-97c9-cbd6cc09fe88
-ARTIFACTS_BUCKET = ala-code-pipeline-artifacts-testing
-CLOUDFORMATION_SERVICE_ROLE = arn:aws:iam::748909248546:role/cloud-formation-service-role-development
-CODEBUILD_SERVICE_ROLE = arn:aws:iam::748909248546:role/service-role/code-build-service-role-development
-CODEPIPELINE_SERVICE_ROLE = arn:aws:iam::748909248546:role/code-pipeline-service-role-development
+ARTIFACTS_BUCKET = ala-code-pipeline-artifacts-748909-ap-southeast-2-production
+CLOUDFORMATION_SERVICE_ROLE = arn:aws:iam::748909248546:role/cloud-formation-service-role-production
+CODEBUILD_SERVICE_ROLE = arn:aws:iam::748909248546:role/service-role/code-build-service-role-production
+CODEPIPELINE_SERVICE_ROLE = arn:aws:iam::748909248546:role/code-pipeline-service-role-production
 # bucket
 SOURCE_BUCKET = ala-${PRODUCT_NAME}-${ENVIRONMENT}
 MAX_AGE = 30
@@ -81,10 +81,10 @@ DEST_EMAIL=test@ala.org.au
 [staging]
 # code pipeline
 CODESTAR_CONNECTION = arn:aws:codestar-connections:ap-southeast-2:736913556139:connection/a13c92b1-cb4e-437e-ad63-d6035c67fe77
-ARTIFACTS_BUCKET = ala-code-pipeline-artifacts-staging
-CLOUDFORMATION_SERVICE_ROLE = arn:aws:iam::736913556139:role/cloud-formation-service-role-staging
-CODEBUILD_SERVICE_ROLE = arn:aws:iam::736913556139:role/service-role/code-build-service-role-staging
-CODEPIPELINE_SERVICE_ROLE = arn:aws:iam::736913556139:role/code-pipeline-service-role-staging
+ARTIFACTS_BUCKET = ala-code-pipeline-artifacts-736913-ap-southeast-2-production
+CLOUDFORMATION_SERVICE_ROLE = arn:aws:iam::736913556139:role/cloud-formation-service-role-production
+CODEBUILD_SERVICE_ROLE = arn:aws:iam::736913556139:role/service-role/code-build-service-role-production
+CODEPIPELINE_SERVICE_ROLE = arn:aws:iam::736913556139:role/code-pipeline-service-role-production
 # bucket
 SOURCE_BUCKET = ala-${PRODUCT_NAME}-${ENVIRONMENT}
 MAX_AGE = 30
@@ -108,7 +108,7 @@ DEST_EMAIL=support@ala.org.au
 [production]
 # code pipeline
 CODESTAR_CONNECTION = arn:aws:codestar-connections:ap-southeast-2:736913556139:connection/a13c92b1-cb4e-437e-ad63-d6035c67fe77
-ARTIFACTS_BUCKET = ala-code-pipeline-artifacts-production
+ARTIFACTS_BUCKET = ala-code-pipeline-artifacts-736913-ap-southeast-2-production
 CLOUDFORMATION_SERVICE_ROLE = arn:aws:iam::736913556139:role/cloud-formation-service-role-production
 CODEBUILD_SERVICE_ROLE = arn:aws:iam::736913556139:role/service-role/code-build-service-role-production
 CODEPIPELINE_SERVICE_ROLE = arn:aws:iam::736913556139:role/code-pipeline-service-role-production


### PR DESCRIPTION
This change updates the common infrastructure that is used for build and deploy. It needed to be made for Seedbank to allow multi-region deploys for a CloudFront WAF deployment. Updating all the other projects will give them that capability if it's required, it also keeps things clean as we don't want to be maintaining and supporting parallel infrastructure where some products use one and some use another.

Also taking the opportunity to slightly change the thinking around common infrastructure, all projects will use the production versions by default. stage, test and dev versions are reserved for testing changes in common infrastructure and may not be stable or present in each account