### PR TITLE
Retrieve Access Token

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -44,8 +44,8 @@ HOSTED_ZONE_ID = Z0205454134UILBVG0TC
 SSL_CERTIFICATE = arn:aws:acm:us-east-1:748909248546:certificate/44fe9e04-6511-4a46-a0b8-36209d443f21
 DOCUMENT_ROOT = index.html 
 # app
-VITE_OIDC_AUTHORITY=https://cognito-idp.ap-southeast-2.amazonaws.com/ap-southeast-2_OOXU9GW39
-VITE_COGNITO_LOGOUT_URI=https://auth-secure.auth.ap-southeast-2.amazoncognito.com/logout
+VITE_OIDC_AUTHORITY=https://cognito-idp.ap-southeast-2.amazonaws.com/ap-southeast-2_pQUl30qBX
+VITE_COGNITO_LOGOUT_URI=https://auth-secure-development.auth.ap-southeast-2.amazoncognito.com/logout
 VITE_OIDC_REDIRECT_URI=https://${SUB_DOMAIN}.${HOSTED_ZONE}/login
 VITE_OIDC_LOGOUT_REDIRECT_URI=https://${SUB_DOMAIN}.${HOSTED_ZONE}/logout
 VITE_TOKENS_API=https://api.test.ala.org.au/tokens

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,104 +1,26 @@
-import { MantineProvider, Global, AppShell, Header, MediaQuery, Burger,  Image } from '@mantine/core';
-import { Fragment, useState } from 'react';
-import AppNavbar from './components/navbar';
 
-import LargeLogo from '../src/ala-logo.png' 
+import { Fragment } from 'react';
+
 
 // Config helper
-import config from './helpers/config';
-import UI from './components/token-ui';
-import Faq from './components/faq';
-import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
+
+
+import { BrowserRouter as Router, Route, Routes, useSearchParams } from 'react-router-dom';
 import LoginCallback from './components/login-callback';
 import LogoutCallback from './components/logout-callback';
-
-if (import.meta.env.DEV) {
-  console.log(JSON.stringify(config, null, 2));
-}
+import TokensPortal from './components/tokens-portal';
+import AccessToken from './components/access-token';
 
 function App(): React.ReactElement {
-  const [opened, setOpened] = useState(false);
-
-  const [activeAside, setActiveAside] = useState("Credentials & Tokens");
 
   return (
     <Fragment>
       <Router>
         <Routes>
-        <Route path="/logout" element={<LogoutCallback />} />
+          <Route path="/logout" element={<LogoutCallback />} />
           <Route path="/login" element={<LoginCallback />} />
-          <Route path="/" element={   
-            <MantineProvider 
-                theme={{
-                  colorScheme: 'light',
-                  fontFamily: 'Roboto, sans-serif',
-                  headings: {
-                    fontFamily: 'Lato, sans-serif',
-                  },
-                  primaryColor:'rust',
-                  colors: {
-                    rust: [
-                      '#000000',
-                      '#000000',
-                      '#FDEBE7',
-                      '#FAC7BC',
-                      '#F7A392',
-                      '#F47F67',
-                      '#F15B3C',
-                      '#EE3711',
-                      '#BE2C0E',
-                      '#8F210A',
-                    ],
-                  },
-                }}
-                withGlobalStyles withNormalizeCSS
-              >
-              <Global
-                styles={(theme) => ({
-                  body: {
-                    backgroundColor:
-                      theme.colorScheme === 'dark'
-                        ? theme.colors.dark[7]
-                        : theme.colors.gray[0],
-                  },
-                })}
-              />
-
-
-              <AppShell
-              styles={{
-                main: {
-                  maxHeight: "100vh",
-                  overflowY: "scroll",
-                  overflowX: "hidden",
-                },
-              }}
-                navbarOffsetBreakpoint="sm"
-                asideOffsetBreakpoint="sm"
-                navbar={ <AppNavbar opened={opened} updateNavContent={setActiveAside} />
-                }
-                header={
-                  <Header height="10" p="sm">
-                    <div style={{ display: 'flex', alignItems: 'center', height: '100%' }}>
-                      <MediaQuery largerThan="sm" styles={{ display: 'none' }}>
-                        <Burger
-                          opened={opened}
-                          onClick={() => setOpened((o) => !o)}
-                          size="sm"
-                          color={"red"}
-                          mr="xl"
-                        />
-                      </MediaQuery>
-                      <Image width={200} style={{margin: '0px 50px 0px 0px'}}  src={LargeLogo} ></Image> <h2>Client Credentials & Tokens</h2>
-                    </div>
-                  </Header>
-                }
-              >
-              {activeAside === "Credentials & Tokens" && <UI config={config} /> }
-              {activeAside === "FAQ" && <Faq /> }
-
-              </AppShell>
-            </MantineProvider>} />
+          <Route path="/" element={ <TokensPortal /> } />
+          <Route path='/token' element={ <AccessToken /> } />
         </Routes>
       </Router>
     </Fragment>

--- a/src/components/access-token.tsx
+++ b/src/components/access-token.tsx
@@ -1,58 +1,76 @@
 import { useEffect, useState } from "react";
 import config, { AuthConfig } from "../helpers/config";
 
-import { User, UserManager } from 'oidc-client-ts';
-
 import Auth from './token-generation';
 import { useSearchParams } from "react-router-dom";
+import { MantineProvider } from "@mantine/core";
 
 function AccessToken(): React.ReactElement {
- 
-    // const [clientId, setClientId] = useState("");
-    // const [scope, setScope] = useState("openid email profile ala/roles");
 
-    const [searchParams, setSearchParams] = useSearchParams();
+  const [clientId, setClientId] = useState("");
+  const [scope, setScope] = useState("openid email profile ala/roles");
 
-    useEffect(() => {
-        // check url param for app `step` and set the visibility of app client registration accordingly.
+  const [searchParams, setSearchParams] = useSearchParams();
 
-          // const clientId = searchParams.get('client_id');
-          // const scope = searchParams.get('scope');
+  const [loading, setLoading] = useState(true);
 
-          // if(clientId){
-          //   setClientId(clientId)
-          //   setSearchParams('');
-          // }
+  useEffect(() => {
+    // check url param for app `step` and set the visibility of app client registration accordingly.
+    const clientId = searchParams.get('client_id');
+    const scope = searchParams.get('scope');
 
-          // if(scope){
-          //   setScope(scope)
-          // }
-          // remove url params after registration visibility state is updated. 
+    if (clientId) {
+      setClientId(clientId)
+    }
 
+    if (scope) {
+      setScope(scope)
+    }
+    // remove url params after registration visibility state is updated. 
 
-        // const userManager = new UserManager({ client_id:clientId, scope, authority: config.authority, redirect_uri: config.redirect_uri, cognito_logout_uri: config.cognito_logout_uri, popup_post_logout_redirect_uri: config.popup_post_logout_redirect_uri} as AuthConfig);
-        // const user = userManager.signinRedirect();
-    });
+    setLoading(false);
 
-    const clientDetails  = (): AuthConfig => {
-      
-      const clientId = searchParams.get('client_id') || config.client_id;
-      const scope = searchParams.get('scope') || config.scope;
+    // const userManager = new UserManager({ client_id:clientId, scope, authority: config.authority, redirect_uri: config.redirect_uri, cognito_logout_uri: config.cognito_logout_uri, popup_post_logout_redirect_uri: config.popup_post_logout_redirect_uri} as AuthConfig);
+    // const user = userManager.signinRedirect();
+  }, []);
 
-      // if(clientIdParam){
-      //   setClientId(clientIdParam)
-      // }
+  const clientDetails = (): AuthConfig => {
+    return { client_id: clientId, scope: scope, authority: config.authority, redirect_uri: config.redirect_uri, cognito_logout_uri: config.cognito_logout_uri, popup_post_logout_redirect_uri: config.popup_post_logout_redirect_uri }
+  }
 
-      // if(scopeParam){
-      //   setScope(scopeParam)
-      // }
+  if (!loading) {
 
-        return {client_id: clientId, scope, authority: config.authority, redirect_uri: config.redirect_uri, cognito_logout_uri: config.cognito_logout_uri, popup_post_logout_redirect_uri: config.popup_post_logout_redirect_uri}
-      }
-
+    console.log('render <Auth>')
     return (
-        <Auth clientDetails={clientDetails()} getToken={true}/>
+      <MantineProvider
+              theme={{
+                colorScheme: 'light',
+                fontFamily: 'Roboto, sans-serif',
+                headings: {
+                  fontFamily: 'Lato, sans-serif',
+                },
+                primaryColor: 'rust',
+                colors: {
+                  rust: [
+                    '#000000',
+                    '#000000',
+                    '#FDEBE7',
+                    '#FAC7BC',
+                    '#F7A392',
+                    '#F47F67',
+                    '#F15B3C',
+                    '#EE3711',
+                    '#BE2C0E',
+                    '#8F210A',
+                  ],
+                },
+              }}
+              withGlobalStyles withNormalizeCSS
+            >
+        <Auth clientDetails={clientDetails()} getToken={true} />
+      </MantineProvider>
     );
+  }
 }
 
 export default AccessToken;

--- a/src/components/access-token.tsx
+++ b/src/components/access-token.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import config, { AuthConfig } from "../helpers/config";
+
+import { User, UserManager } from 'oidc-client-ts';
+
+import Auth from './token-generation';
+import { useSearchParams } from "react-router-dom";
+
+function AccessToken(): React.ReactElement {
+ 
+    // const [clientId, setClientId] = useState("");
+    // const [scope, setScope] = useState("openid email profile ala/roles");
+
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    useEffect(() => {
+        // check url param for app `step` and set the visibility of app client registration accordingly.
+
+          // const clientId = searchParams.get('client_id');
+          // const scope = searchParams.get('scope');
+
+          // if(clientId){
+          //   setClientId(clientId)
+          //   setSearchParams('');
+          // }
+
+          // if(scope){
+          //   setScope(scope)
+          // }
+          // remove url params after registration visibility state is updated. 
+
+
+        // const userManager = new UserManager({ client_id:clientId, scope, authority: config.authority, redirect_uri: config.redirect_uri, cognito_logout_uri: config.cognito_logout_uri, popup_post_logout_redirect_uri: config.popup_post_logout_redirect_uri} as AuthConfig);
+        // const user = userManager.signinRedirect();
+    });
+
+    const clientDetails  = (): AuthConfig => {
+      
+      const clientId = searchParams.get('client_id') || config.client_id;
+      const scope = searchParams.get('scope') || config.scope;
+
+      // if(clientIdParam){
+      //   setClientId(clientIdParam)
+      // }
+
+      // if(scopeParam){
+      //   setScope(scopeParam)
+      // }
+
+        return {client_id: clientId, scope, authority: config.authority, redirect_uri: config.redirect_uri, cognito_logout_uri: config.cognito_logout_uri, popup_post_logout_redirect_uri: config.popup_post_logout_redirect_uri}
+      }
+
+    return (
+        <Auth clientDetails={clientDetails()} getToken={true}/>
+    );
+}
+
+export default AccessToken;

--- a/src/components/access-token.tsx
+++ b/src/components/access-token.tsx
@@ -64,7 +64,7 @@ function AccessToken(): React.ReactElement {
       }}
       withGlobalStyles withNormalizeCSS
     >
-      { (loading) ? null : <Auth clientDetails={clientDetails()} getToken={true} /> }
+      { (!loading) && <Auth clientDetails={clientDetails()} getToken={true} /> }
     </MantineProvider>
   );
 

--- a/src/components/access-token.tsx
+++ b/src/components/access-token.tsx
@@ -64,7 +64,7 @@ function AccessToken(): React.ReactElement {
       }}
       withGlobalStyles withNormalizeCSS
     >
-      (loading) ? null : <Auth clientDetails={clientDetails()} getToken={true} />
+      { (loading) ? null : <Auth clientDetails={clientDetails()} getToken={true} /> }
     </MantineProvider>
   );
 

--- a/src/components/access-token.tsx
+++ b/src/components/access-token.tsx
@@ -38,39 +38,37 @@ function AccessToken(): React.ReactElement {
     return { client_id: clientId, scope: scope, authority: config.authority, redirect_uri: config.redirect_uri, cognito_logout_uri: config.cognito_logout_uri, popup_post_logout_redirect_uri: config.popup_post_logout_redirect_uri }
   }
 
-  if (!loading) {
+  return (
+    <MantineProvider
+      theme={{
+        colorScheme: 'light',
+        fontFamily: 'Roboto, sans-serif',
+        headings: {
+          fontFamily: 'Lato, sans-serif',
+        },
+        primaryColor: 'rust',
+        colors: {
+          rust: [
+            '#000000',
+            '#000000',
+            '#FDEBE7',
+            '#FAC7BC',
+            '#F7A392',
+            '#F47F67',
+            '#F15B3C',
+            '#EE3711',
+            '#BE2C0E',
+            '#8F210A',
+          ],
+        },
+      }}
+      withGlobalStyles withNormalizeCSS
+    >
+      (loading) ? null : <Auth clientDetails={clientDetails()} getToken={true} />
+    </MantineProvider>
+  );
 
-    console.log('render <Auth>')
-    return (
-      <MantineProvider
-              theme={{
-                colorScheme: 'light',
-                fontFamily: 'Roboto, sans-serif',
-                headings: {
-                  fontFamily: 'Lato, sans-serif',
-                },
-                primaryColor: 'rust',
-                colors: {
-                  rust: [
-                    '#000000',
-                    '#000000',
-                    '#FDEBE7',
-                    '#FAC7BC',
-                    '#F7A392',
-                    '#F47F67',
-                    '#F15B3C',
-                    '#EE3711',
-                    '#BE2C0E',
-                    '#8F210A',
-                  ],
-                },
-              }}
-              withGlobalStyles withNormalizeCSS
-            >
-        <Auth clientDetails={clientDetails()} getToken={true} />
-      </MantineProvider>
-    );
-  }
 }
+
 
 export default AccessToken;

--- a/src/components/access-token.tsx
+++ b/src/components/access-token.tsx
@@ -8,6 +8,7 @@ import { MantineProvider } from "@mantine/core";
 function AccessToken(): React.ReactElement {
 
   const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
   const [scope, setScope] = useState("openid email profile ala/roles");
 
   const [searchParams, setSearchParams] = useSearchParams();
@@ -17,10 +18,15 @@ function AccessToken(): React.ReactElement {
   useEffect(() => {
     // check url param for app `step` and set the visibility of app client registration accordingly.
     const clientId = searchParams.get('client_id');
+    const clientSecret = searchParams.get('client_secret');
     const scope = searchParams.get('scope');
 
     if (clientId) {
       setClientId(clientId)
+    }
+
+    if (clientSecret){
+      setClientSecret(clientSecret)
     }
 
     if (scope) {
@@ -35,7 +41,7 @@ function AccessToken(): React.ReactElement {
   }, []);
 
   const clientDetails = (): AuthConfig => {
-    return { client_id: clientId, scope: scope, authority: config.authority, redirect_uri: config.redirect_uri, cognito_logout_uri: config.cognito_logout_uri, popup_post_logout_redirect_uri: config.popup_post_logout_redirect_uri }
+    return {client_id: clientId, client_secret: clientSecret, scope, authority: config.authority, redirect_uri: config.redirect_uri, cognito_logout_uri: config.cognito_logout_uri, popup_post_logout_redirect_uri: config.popup_post_logout_redirect_uri}
   }
 
   return (

--- a/src/components/token-generation.tsx
+++ b/src/components/token-generation.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Container,
   Center,
@@ -16,7 +16,7 @@ import { IconAlertCircle, IconDownload} from '@tabler/icons';
 import { User, UserManager } from 'oidc-client-ts';
 import { AuthConfig } from '../helpers/config';
 
-const Auth: React.FC<{clientDetails : AuthConfig}> = ({clientDetails}) => {
+const Auth: React.FC<{clientDetails : AuthConfig, getToken: boolean}> = ({clientDetails, getToken}) => {
   // set and empty user state on initial setup.
   const [user, setUser] = useState(new User({access_token:"", token_type:"", profile: {sub:"", aud:"", exp:0, iat: 0, iss:""}}));
   // loading state
@@ -26,6 +26,15 @@ const Auth: React.FC<{clientDetails : AuthConfig}> = ({clientDetails}) => {
 
   const [hasError, setHasError] = useState(false);
 
+  console.log('client details', clientDetails)
+
+  useEffect(() => {
+    // if getToken is true, generate token
+    if ( getToken && !user.access_token){
+      console.log('get token')
+      signIn();
+    }
+  }, [ userManager ]);
 
   const signIn = async () =>{
     /**
@@ -42,6 +51,7 @@ const Auth: React.FC<{clientDetails : AuthConfig}> = ({clientDetails}) => {
       const  user = await userManager.signinPopup();
       setUser(user);
     } catch (e) {
+      console.error(e);
        setHasError(true);
     } finally {
       setIsLoading(false);

--- a/src/components/token-ui.tsx
+++ b/src/components/token-ui.tsx
@@ -131,7 +131,7 @@ const  UI: React.FC<{config: AuthConfig}> = ({config}) => {
                 </Stepper.Step>
 
                 <Stepper.Step label="Token Generation" description="Generate a JWT token">
-                    <Auth clientDetails={clientDetails()}/>
+                    <Auth clientDetails={clientDetails()} getToken={false} />
                 </Stepper.Step>
             </Stepper>
     

--- a/src/components/tokens-portal.tsx
+++ b/src/components/tokens-portal.tsx
@@ -1,0 +1,98 @@
+import { MantineProvider, Global, AppShell, Header, MediaQuery, Burger, Image } from '@mantine/core';
+
+import AppNavbar from './navbar';
+
+import LargeLogo from '../ala-logo.png'
+import config, { AuthConfig } from '../helpers/config';
+
+import UI from './token-ui';
+import Faq from './faq';
+import { useState } from 'react';
+
+if (import.meta.env.DEV) {
+    console.log(JSON.stringify(config, null, 2));
+  }
+  
+
+function TokensPortal(): React.ReactElement {
+
+    const [opened, setOpened] = useState(false);
+
+    const [activeAside, setActiveAside] = useState("Credentials & Tokens");
+
+    return (
+    <MantineProvider
+              theme={{
+                colorScheme: 'light',
+                fontFamily: 'Roboto, sans-serif',
+                headings: {
+                  fontFamily: 'Lato, sans-serif',
+                },
+                primaryColor: 'rust',
+                colors: {
+                  rust: [
+                    '#000000',
+                    '#000000',
+                    '#FDEBE7',
+                    '#FAC7BC',
+                    '#F7A392',
+                    '#F47F67',
+                    '#F15B3C',
+                    '#EE3711',
+                    '#BE2C0E',
+                    '#8F210A',
+                  ],
+                },
+              }}
+              withGlobalStyles withNormalizeCSS
+            >
+              <Global
+                styles={(theme) => ({
+                  body: {
+                    backgroundColor:
+                      theme.colorScheme === 'dark'
+                        ? theme.colors.dark[7]
+                        : theme.colors.gray[0],
+                  },
+                })}
+              />
+
+                <AppShell
+                  styles={{
+                    main: {
+                      maxHeight: "100vh",
+                      overflowY: "scroll",
+                      overflowX: "hidden",
+                    },
+                  }}
+                  navbarOffsetBreakpoint="sm"
+                  asideOffsetBreakpoint="sm"
+                  navbar={<AppNavbar opened={opened} updateNavContent={setActiveAside} />
+                  }
+                  header={
+                    <Header height="10" p="sm">
+                      <div style={{ display: 'flex', alignItems: 'center', height: '100%' }}>
+                        <MediaQuery largerThan="sm" styles={{ display: 'none' }}>
+                          <Burger
+                            opened={opened}
+                            onClick={() => setOpened((o) => !o)}
+                            size="sm"
+                            color={"red"}
+                            mr="xl"
+                          />
+                        </MediaQuery>
+                        <Image width={200} style={{ margin: '0px 50px 0px 0px' }} src={LargeLogo} ></Image> <h2>Client Credentials & Tokens</h2>
+                      </div>
+                    </Header>
+                  }
+                >
+                  {activeAside === "Credentials & Tokens" && <UI config={config} />}
+                  {activeAside === "FAQ" && <Faq />}
+
+                </AppShell>
+            
+            </MantineProvider>
+            )
+}
+
+export default TokensPortal;


### PR DESCRIPTION
Refactor of the Tokens Portal to create a route to the token generation step that will accept `client_id` and `scope` as query parameters to retrieve an access token without user interaction. 

The intent is to link to this route from the user details -> "My applications" page to create an access token for testing purposes. 

Navigate to `/token` with query parameters:
 - `client_id` required
 - `scope` optional 

If the browser is authenticated the access token is displayed, otherwise a popup will prompt for credentials then display the access token.