### PR TITLE
Update clean_branch rules

### DIFF
--- a/cicd/pipeline/clean_branch.sh
+++ b/cicd/pipeline/clean_branch.sh
@@ -7,4 +7,5 @@
 
 SRC_BRANCH=$1
 
-echo $SRC_BRANCH | sed 's/^feature\///' | sed 's/[/_]/-/g' | sed 's/[^a-zA-Z0-9-]//g' | tr '[:upper:]' '[:lower:]' | cut -c 1-30
+echo -n $SRC_BRANCH | sed 's/^feature\///' | sed 's/[/_]/-/g' | sed 's/[^a-zA-Z0-9-]//g' | tr '[:upper:]' '[:lower:]' | cut -c 1-30 | sed -E 's/[^a-z0-9]+$//'
+


### PR DESCRIPTION
Some updates to the logic to create the clean_branch. This should only affect feature branches
- remove any trailing - chars. This can happen after truncation and when used in AWS resource names it was causing errors in these cases
- dont echo the newline